### PR TITLE
Document virtualenv setup for dependencies

### DIFF
--- a/edge_project/README.md
+++ b/edge_project/README.md
@@ -53,12 +53,18 @@ edge_project/
 
 ## Getting Started
 
-Install dependencies and run migrations:
+Install dependencies inside a virtual environment and run migrations:
 
 ```bash
-pip install -r requirements.txt
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
 python manage.py migrate
 ```
+
+> **Note:** Debian-based systems ship with an *externally managed* Python where the
+> global `pip` executable is disabled. Creating a virtual environment ensures the
+> dependencies install cleanly without requiring system package changes.
 
 Then configure a `LocationSettings` record (via admin or Django shell) before invoking the management commands, e.g.:
 


### PR DESCRIPTION
## Summary
- update the setup instructions to create a Python virtual environment before installing requirements
- explain why Debian users may encounter the externally managed pip message and how the venv resolves it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3db3b560c832cbe5e16e5ff429680