### PR TITLE
Add bootstrap helper for virtualenv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,19 @@ This repository contains a Django-based edge service that bridges Hikvision DS-7
 - Service abstractions that encapsulate Hikvision ISAPI communication and resilient HTTP uploads to the central system.
 
 See [`edge_project/README.md`](edge_project/README.md) for detailed setup and usage instructions.
+
+## Quick start
+
+Create the project virtual environment and install dependencies by running the
+provided bootstrap script (this avoids the "externally managed" system Python
+error shown above):
+
+```bash
+./bootstrap.sh
+```
+
+Afterwards activate the environment before using Django management commands:
+
+```bash
+source edge_project/.venv/bin/activate
+```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$REPO_ROOT/edge_project"
+
+PYTHON_BIN="${PYTHON:-python3}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Error: $PYTHON_BIN is not installed." >&2
+  exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+if [ ! -d .venv ]; then
+  "$PYTHON_BIN" -m venv .venv
+fi
+
+source .venv/bin/activate
+
+if ! python -m pip install --upgrade pip; then
+  echo "Warning: unable to upgrade pip (check network connectivity)." >&2
+fi
+
+if ! python -m pip install -r requirements.txt; then
+  echo "Error: failed to install Python dependencies. Check network or proxy settings." >&2
+  exit 1
+fi
+
+echo "Virtual environment created at $PROJECT_DIR/.venv"
+echo "Run 'source edge_project/.venv/bin/activate' before using manage.py."

--- a/edge_project/README.md
+++ b/edge_project/README.md
@@ -53,7 +53,15 @@ edge_project/
 
 ## Getting Started
 
-Install dependencies inside a virtual environment and run migrations:
+Install dependencies inside a virtual environment and run migrations. You can
+either execute the repository's `bootstrap.sh` helper from the repo root or run
+the commands manually as shown below.
+
+```bash
+./bootstrap.sh
+```
+
+If you prefer to perform the steps yourself:
 
 ```bash
 python3 -m venv .venv
@@ -63,8 +71,9 @@ python manage.py migrate
 ```
 
 > **Note:** Debian-based systems ship with an *externally managed* Python where the
-> global `pip` executable is disabled. Creating a virtual environment ensures the
-> dependencies install cleanly without requiring system package changes.
+> global `pip` executable is disabled. Creating a virtual environment (or using
+> the `bootstrap.sh` helper) ensures the dependencies install cleanly without
+> requiring system package changes.
 
 Then configure a `LocationSettings` record (via admin or Django shell) before invoking the management commands, e.g.:
 


### PR DESCRIPTION
## Summary
- add a bootstrap script that creates a virtual environment and installs project dependencies
- document the helper workflow in both READMEs so developers avoid the externally managed pip error

## Testing
- ./bootstrap.sh *(fails: blocked from reaching package index in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dd2afb7c832ca163fe1aaed7025c